### PR TITLE
Fix grids statsd port type

### DIFF
--- a/api/grids.go
+++ b/api/grids.go
@@ -2,7 +2,7 @@ package api
 
 type GridStatsStatsd struct {
 	Server string `json:"server"`
-	Port   string `json:"port"` // XXX: really?
+	Port   int    `json:"port"`
 }
 
 type GridStats struct {

--- a/client/grids_test.go
+++ b/client/grids_test.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGridsList(t *testing.T) {
+	var test = makeTest()
+
+	test.mockGET("/v1/grids", "test-data/grids.json")
+
+	if grids, err := test.client.Grids.List(); err != nil {
+		t.Fatalf("grids list error: %v", err)
+	} else {
+		assert.Equal(t, len(grids), 1, "array len")
+		assert.Equal(t, grids[0].ID, "test", "grid id")
+	}
+}

--- a/client/test-data/grids.json
+++ b/client/test-data/grids.json
@@ -1,0 +1,32 @@
+{
+   "grids" : [
+      {
+         "id" : "test",
+         "user_count" : 1,
+         "service_count" : 0,
+         "default_affinity" : [
+            "label==test"
+         ],
+         "logs" : {
+            "opts" : {
+               "fluentd-address" : "127.0.0.1"
+            },
+            "forwarder" : "fluentd"
+         },
+         "container_count" : 0,
+         "token" : "5z5....57Q==",
+         "stats" : {
+            "statsd" : {
+               "port" : 8125,
+               "server" : "127.0.0.1"
+            }
+         },
+         "initial_size" : 1,
+         "node_count" : 0,
+         "trusted_subnets" : [],
+         "name" : "test-options",
+         "supernet" : "10.80.0.0/12",
+         "subnet" : "10.79.0.0/16"
+      }
+   ]
+}


### PR DESCRIPTION
```
 CRIT kontena-cli.main: Invalid response JSON: json: cannot unmarshal number into Go struct field GridStatsStatsd.port of type string
```

https://github.com/kontena/kontena/issues/2610

