### PR TITLE
client: grids create/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Golang Kontena API client library.
 
+***DISCLAIMER***: This client library is a work in progress, and is intended for use with the Kontena 1.4 development version. 
+
 ## Usage / Examples
 
 ### `./cli/commands`
@@ -57,9 +59,11 @@ Includes support for OAuth2 tokens and code exchanges.
 
 ## API Support
 
-This client library is a work in progress, and support is limited to the following APIs:
+This client library is a work in progress, and support is limited to the following Kontena APIs:
 
 * `/oauth2`
 * `/v1/user`
 * `/v1/grids`
 * `/v1/nodes`
+
+This library is currently compatible with the Kontena 1.4 development version.

--- a/api/grids.go
+++ b/api/grids.go
@@ -56,7 +56,10 @@ type GridPOST struct {
 	Supernet string `json:"supernet,omitempty"`
 
 	// Optional
+	TrustedSubnets  *GridTrustedSubnets  `json:"trusted_subnets,omitempty"`
 	DefaultAffinity *GridDefaultAffinity `json:"default_affinity,omitempty"`
+	Stats           *GridStats           `json:"stats,omitempty"`
+	Logs            *GridLogs            `json:"logs,omitempty"`
 }
 
 type GridPUT struct {

--- a/api/grids.go
+++ b/api/grids.go
@@ -9,9 +9,11 @@ type GridStats struct {
 	Statsd *GridStatsStatsd `json:"statsd"`
 }
 
+type GridLogsOpts map[string]string
+
 type GridLogs struct {
-	Forwarder string            `json:"forwarder"`
-	Opts      map[string]string `json:"opts"`
+	Forwarder string       `json:"forwarder"`
+	Opts      GridLogsOpts `json:"opts"`
 }
 
 type GridTrustedSubnets []string
@@ -49,13 +51,16 @@ type GridPOST struct {
 	InitialSize int    `json:"initial_size"`
 
 	// Optional
-	Token           *string              `json:"token,omitempty"`
+	Token    string `json:"token,omitempty"`
+	Subnet   string `json:"subnet,omitempty"`
+	Supernet string `json:"supernet,omitempty"`
+
+	// Optional
 	DefaultAffinity *GridDefaultAffinity `json:"default_affinity,omitempty"`
-	Subnet          *string              `json:"subnet,omitempty"`
-	Supernet        *string              `json:"supernet,omitempty"`
 }
 
 type GridPUT struct {
+	// Optional
 	TrustedSubnets  *GridTrustedSubnets  `json:"trusted_subnets,omitempty"`
 	DefaultAffinity *GridDefaultAffinity `json:"default_affinity,omitempty"`
 	Stats           *GridStats           `json:"stats,omitempty"`

--- a/client/grids_test.go
+++ b/client/grids_test.go
@@ -51,3 +51,63 @@ func TestGridCreate(t *testing.T) {
 		assert.Equal(t, grid.Token, "secret")
 	}
 }
+
+func TestGridCreateOptions(t *testing.T) {
+	var test = makeTest()
+	var gridParams = api.GridPOST{
+		Name:        "test-options",
+		InitialSize: 3,
+		Token:       "secret 2",
+		Subnet:      "10.8.0.0/16",
+		Supernet:    "10.0.0.0/8",
+		TrustedSubnets: &api.GridTrustedSubnets{
+			"192.168.66.0/24",
+		},
+		DefaultAffinity: &api.GridDefaultAffinity{"test==true"},
+		Stats: &api.GridStats{
+			Statsd: &api.GridStatsStatsd{
+				Server: "127.0.0.1",
+				Port:   8125,
+			},
+		},
+		Logs: &api.GridLogs{
+			Forwarder: "test",
+			Opts: api.GridLogsOpts{
+				"server": "localhost",
+			},
+		},
+	}
+	var mockRequest = parseJSON(`
+    {
+      "name":             "test-options",
+      "initial_size":     3,
+      "token":            "secret 2",
+      "subnet":           "10.8.0.0/16",
+      "supernet":         "10.0.0.0/8",
+      "trusted_subnets":  ["192.168.66.0/24"],
+      "default_affinity": ["test==true"],
+      "logs": {
+        "forwarder": "test",
+        "opts": { "server": "localhost" }
+      },
+      "stats": {
+        "statsd": {
+          "server": "127.0.0.1",
+          "port": 8125
+        }
+      }
+    }
+  `)
+
+	test.mockPOST(t, "/v1/grids", func(request mockJSON) interface{} {
+		assert.Equal(t, mockRequest, request, "POST /v1/grids JSON")
+
+		return api.Grid{ID: "test"}
+	})
+
+	if grid, err := test.client.Grids.Create(gridParams); err != nil {
+		t.Fatalf("grids create error: %v", err)
+	} else {
+		assert.Equal(t, grid.ID, "test")
+	}
+}

--- a/client/grids_test.go
+++ b/client/grids_test.go
@@ -111,3 +111,46 @@ func TestGridCreateOptions(t *testing.T) {
 		assert.Equal(t, grid.ID, "test")
 	}
 }
+
+func testGridUpdate(t *testing.T, id string, gridParams api.GridPUT, mockRequest mockJSON) {
+	var test = makeTest()
+
+	test.mockPUT(t, "/v1/grids/"+id, func(request mockJSON) interface{} {
+		assert.Equal(t, mockRequest, request, "PUT /v1/grids/"+id+" JSON")
+
+		return api.Grid{ID: id}
+	})
+
+	if grid, err := test.client.Grids.Update(id, gridParams); err != nil {
+		t.Fatalf("grids create error: %v", err)
+	} else {
+		assert.Equal(t, grid.ID, id)
+	}
+}
+
+func TestGridUpdateDefaults(t *testing.T) {
+	var gridParams = api.GridPUT{}
+	var mockRequest = parseJSON(`{}`)
+
+	testGridUpdate(t, "test-defaults", gridParams, mockRequest)
+}
+
+func TestGridUpdateTrustedSubnetsClear(t *testing.T) {
+	var gridParams = api.GridPUT{
+		TrustedSubnets: &api.GridTrustedSubnets{},
+	}
+	var mockRequest = parseJSON(`{"trusted_subnets": []}`)
+
+	testGridUpdate(t, "test-trusted-subnets-clear", gridParams, mockRequest)
+}
+
+func TestGridUpdateTrustedSubnets(t *testing.T) {
+	var gridParams = api.GridPUT{
+		TrustedSubnets: &api.GridTrustedSubnets{
+			"192.168.66.0/24",
+		},
+	}
+	var mockRequest = parseJSON(`{"trusted_subnets": [ "192.168.66.0/24" ]}`)
+
+	testGridUpdate(t, "test-trusted-subnets", gridParams, mockRequest)
+}

--- a/client/grids_test.go
+++ b/client/grids_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/kontena/kontena-client-go/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,5 +17,37 @@ func TestGridsList(t *testing.T) {
 	} else {
 		assert.Equal(t, len(grids), 1, "array len")
 		assert.Equal(t, grids[0].ID, "test", "grid id")
+	}
+}
+
+func TestGridCreate(t *testing.T) {
+	var test = makeTest()
+	var gridParams = api.GridPOST{
+		Name:        "test",
+		InitialSize: 1,
+	}
+	var mockRequest = parseJSON(`
+    {
+      "name":         "test",
+      "initial_size": 1
+    }
+  `)
+
+	test.mockPOST(t, "/v1/grids", func(request mockJSON) interface{} {
+		assert.Equal(t, mockRequest, request, "POST /v1/grids JSON")
+
+		return api.Grid{
+			ID:          "test",
+			Name:        "test",
+			InitialSize: 1,
+			Token:       "secret",
+		}
+	})
+
+	if grid, err := test.client.Grids.Create(gridParams); err != nil {
+		t.Fatalf("grids create error: %v", err)
+	} else {
+		assert.Equal(t, grid.ID, "test")
+		assert.Equal(t, grid.Token, "secret")
 	}
 }


### PR DESCRIPTION
* Fix `api.GridPOST` to not use `*string` for default params, just omit empty strrings
* Test `client.GridsAPI`
* New 1.4 #2488 `POST /v1/grids` parameters