### PR TITLE
Fix client config.URL validation to reject empty URL

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,7 +18,7 @@ func (config Config) MakeClient() (*Client, error) {
 	}
 
 	if apiURL, err := config.makeURL(); err != nil {
-		return nil, fmt.Errorf("Invalid API URL %v: %v", config.URL, err)
+		return nil, fmt.Errorf("Invalid API URL=%#v: %v", config.URL, err)
 	} else {
 		client.apiURL = apiURL
 	}

--- a/client/config.go
+++ b/client/config.go
@@ -31,7 +31,9 @@ func (config Config) isSSL() bool {
 }
 
 func (config Config) makeURL(path ...string) (*url.URL, error) {
-	if baseURL, err := url.Parse(config.URL); err != nil {
+	if config.URL == "" {
+		return nil, fmt.Errorf("Missing config.URL")
+	} else if baseURL, err := url.Parse(config.URL); err != nil {
 		return nil, err
 	} else if pathURL, err := baseURL.Parse(strings.Join(path, "/")); err != nil {
 		return nil, err


### PR DESCRIPTION
An empty `client:Confgi.URL` was passing the `makeURL` => `url.Parse(...)`, but resulting in an invalid API request: `Request HTTP GET /v1/external_registries/myproject/us.gcr.io error: Get /v1/external_registries/myproject/us.gcr.io: unsupported protocol scheme ""`.

Explicitly validate for empty URLs, and also improve the resulting error message to make the missing URL more obvious: `Invalid API URL="": Missing config.URL`