### PR TITLE
Introduce structured API ID types

### DIFF
--- a/api/external_registries.go
+++ b/api/external_registries.go
@@ -5,7 +5,7 @@ type ExternalRegistryIndex struct {
 }
 
 type ExternalRegistry struct {
-	ID       string
+	ID       ExternalRegistryID
 	Name     string
 	URL      string
 	Username string

--- a/api/external_registry_id.go
+++ b/api/external_registry_id.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"regexp"
+)
+
+var ExternalRegistryIDRegexp = regexp.MustCompile(`^([a-z0-9_-]+)/(.+)$`)
+
+type ExternalRegistryID struct {
+	Grid string
+	Name string
+}
+
+func (id *ExternalRegistryID) schema() idSchema {
+	return idSchema{&id.Grid, &id.Name}
+}
+
+func ParseExternalRegistryID(str string) (id ExternalRegistryID, err error) {
+	return id, id.schema().parse(str, ExternalRegistryIDRegexp)
+}
+
+func (id *ExternalRegistryID) UnmarshalJSON(buf []byte) error {
+	return id.schema().unmarshalJSON(buf)
+}
+
+func (id ExternalRegistryID) String() string {
+	return id.schema().string()
+}
+
+func (id ExternalRegistryID) MarshalJSON() ([]byte, error) {
+	return id.schema().marshalJSON()
+}

--- a/api/id.go
+++ b/api/id.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type idSchema []*string
+
+func (schema idSchema) parse(str string, re *regexp.Regexp) error {
+	if matches := re.FindStringSubmatch(str); matches == nil {
+		return fmt.Errorf("Invalid ID: %#v", str)
+	} else if len(matches)-1 != len(schema) {
+		panic(fmt.Sprintf("Invalid ID regexp=%#v for schema=%#v", re, schema))
+	} else {
+		for i, part := range schema {
+			*part = matches[1+i]
+		}
+	}
+
+	return nil
+}
+
+func (schema idSchema) unmarshalJSON(buf []byte) error {
+	var str string
+
+	if err := json.Unmarshal(buf, &str); err != nil {
+		return err
+	}
+
+	parts := strings.Split(str, "/")
+
+	if len(parts) != len(schema) {
+		return fmt.Errorf("Invalid JSON ID: %#v", str)
+	}
+
+	for i, part := range schema {
+		*part = parts[i]
+	}
+
+	return nil
+}
+
+func (schema idSchema) string() string {
+	var str string
+
+	for i, part := range schema {
+		if i != 0 {
+			str += "/"
+		}
+		str += *part
+	}
+
+	return str
+}
+
+func (schema idSchema) marshalJSON() ([]byte, error) {
+	return json.Marshal(schema.string())
+}

--- a/api/node_id.go
+++ b/api/node_id.go
@@ -1,10 +1,7 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
 	"regexp"
-	"strings"
 )
 
 var NodeIDRegexp = regexp.MustCompile(`^([a-z0-9_-]+)/([a-z0-9_-]+)$`)
@@ -14,40 +11,22 @@ type NodeID struct {
 	Name string
 }
 
-func ParseNodeID(str string) (id NodeID, err error) {
-	if matches := NodeIDRegexp.FindStringSubmatch(str); matches == nil {
-		return id, fmt.Errorf("Invalid NodeID: %#v", str)
-	} else {
-		id.Grid = matches[1]
-		id.Name = matches[2]
-	}
+func (id *NodeID) schema() idSchema {
+	return idSchema{&id.Grid, &id.Name}
+}
 
-	return id, nil
+func ParseNodeID(str string) (id NodeID, err error) {
+	return id, id.schema().parse(str, NodeIDRegexp)
 }
 
 func (id *NodeID) UnmarshalJSON(buf []byte) error {
-	var str string
-
-	if err := json.Unmarshal(buf, &str); err != nil {
-		return err
-	}
-
-	parts := strings.Split(str, "/")
-
-	if len(parts) != 2 {
-		return fmt.Errorf("Invalid NodeID: %#v", str)
-	}
-
-	id.Grid = parts[0]
-	id.Name = parts[1]
-
-	return nil
+	return id.schema().unmarshalJSON(buf)
 }
 
-func (nodeID NodeID) String() string {
-	return fmt.Sprintf("%s/%s", nodeID.Grid, nodeID.Name)
+func (id NodeID) String() string {
+	return id.schema().string()
 }
 
-func (nodeID NodeID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nodeID.String())
+func (id NodeID) MarshalJSON() ([]byte, error) {
+	return id.schema().marshalJSON()
 }

--- a/api/node_id.go
+++ b/api/node_id.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var NodeIDRegexp = regexp.MustCompile(`^([a-z0-9_-]+)/([a-z0-9_-]+)$`)
+
+type NodeID struct {
+	Grid string
+	Name string
+}
+
+func ParseNodeID(str string) (id NodeID, err error) {
+	if matches := NodeIDRegexp.FindStringSubmatch(str); matches == nil {
+		return id, fmt.Errorf("Invalid NodeID: %#v", str)
+	} else {
+		id.Grid = matches[1]
+		id.Name = matches[2]
+	}
+
+	return id, nil
+}
+
+func (id *NodeID) UnmarshalJSON(buf []byte) error {
+	var str string
+
+	if err := json.Unmarshal(buf, &str); err != nil {
+		return err
+	}
+
+	parts := strings.Split(str, "/")
+
+	if len(parts) != 2 {
+		return fmt.Errorf("Invalid NodeID: %#v", str)
+	}
+
+	id.Grid = parts[0]
+	id.Name = parts[1]
+
+	return nil
+}
+
+func (nodeID NodeID) String() string {
+	return fmt.Sprintf("%s/%s", nodeID.Grid, nodeID.Name)
+}
+
+func (nodeID NodeID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(nodeID.String())
+}

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -1,57 +1,8 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
-	"regexp"
-	"strings"
 	"time"
 )
-
-var NodeIDRegexp = regexp.MustCompile(`^([a-z0-9_-]+)/([a-z0-9_-]+)$`)
-
-type NodeID struct {
-	Grid string
-	Name string
-}
-
-func ParseNodeID(str string) (id NodeID, err error) {
-	if matches := NodeIDRegexp.FindStringSubmatch(str); matches == nil {
-		return id, fmt.Errorf("Invalid NodeID: %#v", str)
-	} else {
-		id.Grid = matches[1]
-		id.Name = matches[2]
-	}
-
-	return id, nil
-}
-
-func (id *NodeID) UnmarshalJSON(buf []byte) error {
-	var str string
-
-	if err := json.Unmarshal(buf, &str); err != nil {
-		return err
-	}
-
-	parts := strings.Split(str, "/")
-
-	if len(parts) != 2 {
-		return fmt.Errorf("Invalid NodeID: %#v", str)
-	}
-
-	id.Grid = parts[0]
-	id.Name = parts[1]
-
-	return nil
-}
-
-func (nodeID NodeID) String() string {
-	return fmt.Sprintf("%s/%s", nodeID.Grid, nodeID.Name)
-}
-
-func (nodeID NodeID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(nodeID.String())
-}
 
 type NodeLabels []string
 

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -26,10 +27,16 @@ func ParseNodeID(str string) (id NodeID, err error) {
 }
 
 func (id *NodeID) UnmarshalJSON(buf []byte) error {
-	parts := strings.Split(string(buf), "/")
+	var str string
+
+	if err := json.Unmarshal(buf, &str); err != nil {
+		return err
+	}
+
+	parts := strings.Split(str, "/")
 
 	if len(parts) != 2 {
-		return fmt.Errorf("Invalid NodeID: %#v", string(buf))
+		return fmt.Errorf("Invalid NodeID: %#v", str)
 	}
 
 	id.Grid = parts[0]
@@ -40,6 +47,10 @@ func (id *NodeID) UnmarshalJSON(buf []byte) error {
 
 func (nodeID NodeID) String() string {
 	return fmt.Sprintf("%s/%s", nodeID.Grid, nodeID.Name)
+}
+
+func (nodeID NodeID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(nodeID.String())
 }
 
 type NodeLabels []string

--- a/cli/commands/nodes.go
+++ b/cli/commands/nodes.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/kontena/kontena-client-go/api"
 	"github.com/kontena/kontena-client-go/cli"
-	"github.com/kontena/kontena-client-go/client"
 )
 
 func nodeStatus(node api.Node) string {
@@ -62,7 +61,7 @@ func (cmd NodesCommand) List() error {
 
 // Show prints details about the given node within the grid.
 func (cmd NodesCommand) Show(name string) error {
-	if node, err := cmd.Client.Nodes.Get(client.NodeID{cmd.Grid, name}); err != nil {
+	if node, err := cmd.Client.Nodes.Get(api.NodeID{cmd.Grid, name}); err != nil {
 		return err
 	} else {
 		return cli.Print(node)

--- a/client/external_registries.go
+++ b/client/external_registries.go
@@ -4,9 +4,9 @@ import "github.com/kontena/kontena-client-go/api"
 
 type ExternalRegistriesAPI interface {
 	List(grid string) ([]api.ExternalRegistry, error)
-	Get(id string) (api.ExternalRegistry, error)
+	Get(id api.ExternalRegistryID) (api.ExternalRegistry, error)
 	Create(grid string, params api.ExternalRegistryPOST) (api.ExternalRegistry, error)
-	Delete(id string) error
+	Delete(id api.ExternalRegistryID) error
 }
 
 type externalRegistriesClient struct {
@@ -19,10 +19,10 @@ func (client externalRegistriesClient) List(grid string) ([]api.ExternalRegistry
 	return index.ExternalRegistries, client.get(request{ResponseBody: &index}, "/v1/grids", grid, "external_registries")
 }
 
-func (client externalRegistriesClient) Get(id string) (api.ExternalRegistry, error) {
+func (client externalRegistriesClient) Get(id api.ExternalRegistryID) (api.ExternalRegistry, error) {
 	var externalRegistry api.ExternalRegistry
 
-	return externalRegistry, client.get(request{ResponseBody: &externalRegistry}, "/v1/external_registries", id)
+	return externalRegistry, client.get(request{ResponseBody: &externalRegistry}, "/v1/external_registries", id.Grid, id.Name)
 }
 
 func (client externalRegistriesClient) Create(grid string, params api.ExternalRegistryPOST) (api.ExternalRegistry, error) {
@@ -31,6 +31,6 @@ func (client externalRegistriesClient) Create(grid string, params api.ExternalRe
 	return externalRegistry, client.post(request{RequestBody: params, ResponseBody: &externalRegistry}, "/v1/grids", grid, "external_registries")
 }
 
-func (client externalRegistriesClient) Delete(id string) error {
-	return client.delete(request{}, "/v1/external_registries", id)
+func (client externalRegistriesClient) Delete(id api.ExternalRegistryID) error {
+	return client.delete(request{}, "/v1/external_registries", id.Grid, id.Name)
 }

--- a/client/external_registries.go
+++ b/client/external_registries.go
@@ -22,7 +22,7 @@ func (client externalRegistriesClient) List(grid string) ([]api.ExternalRegistry
 func (client externalRegistriesClient) Get(id api.ExternalRegistryID) (api.ExternalRegistry, error) {
 	var externalRegistry api.ExternalRegistry
 
-	return externalRegistry, client.get(request{ResponseBody: &externalRegistry}, "/v1/external_registries", id.Grid, id.Name)
+	return externalRegistry, client.get(request{ResponseBody: &externalRegistry}, "/v1/external_registries", id.String())
 }
 
 func (client externalRegistriesClient) Create(grid string, params api.ExternalRegistryPOST) (api.ExternalRegistry, error) {
@@ -32,5 +32,5 @@ func (client externalRegistriesClient) Create(grid string, params api.ExternalRe
 }
 
 func (client externalRegistriesClient) Delete(id api.ExternalRegistryID) error {
-	return client.delete(request{}, "/v1/external_registries", id.Grid, id.Name)
+	return client.delete(request{}, "/v1/external_registries", id.String())
 }

--- a/client/external_registries_test.go
+++ b/client/external_registries_test.go
@@ -68,6 +68,6 @@ func TestExternalRegistryCreate(t *testing.T) {
 	if externalRegistry, err := test.client.ExternalRegistries.Create("test", params); err != nil {
 		t.Fatalf("external-registries create error: %v", err)
 	} else {
-		assert.Equal(t, externalRegistry.ID, "test/images.kontena.io")
+		assert.Equal(t, externalRegistry.ID.String(), "test/images.kontena.io")
 	}
 }

--- a/client/external_registries_test.go
+++ b/client/external_registries_test.go
@@ -17,7 +17,7 @@ func TestExternalRegistryList(t *testing.T) {
 	} else {
 		assert.Equal(t, externalRegistries, []api.ExternalRegistry{
 			api.ExternalRegistry{
-				ID:       "test/images.kontena.io",
+				ID:       api.ExternalRegistryID{"test", "images.kontena.io"},
 				Name:     "images.kontena.io",
 				URL:      "https://images.kontena.io",
 				Username: "test",
@@ -31,11 +31,11 @@ func TestExternalRegistryGet(t *testing.T) {
 
 	test.mockGET("/v1/external_registries/test/images.kontena.io", `{"id":"test/images.kontena.io","name":"images.kontena.io","url":"https://images.kontena.io","username":"test","email":null}`)
 
-	if externalRegistry, err := test.client.ExternalRegistries.Get("test/images.kontena.io"); err != nil {
+	if externalRegistry, err := test.client.ExternalRegistries.Get(api.ExternalRegistryID{"test", "images.kontena.io"}); err != nil {
 		t.Fatalf("external-registry get error: %v", err)
 	} else {
 		assert.Equal(t, externalRegistry, api.ExternalRegistry{
-			ID:       "test/images.kontena.io",
+			ID:       api.ExternalRegistryID{"test", "images.kontena.io"},
 			Name:     "images.kontena.io",
 			URL:      "https://images.kontena.io",
 			Username: "test",
@@ -58,7 +58,7 @@ func TestExternalRegistryCreate(t *testing.T) {
 		assert.Equal(t, mockRequest, request, "POST /v1/grids/../external_registries JSON")
 
 		return api.ExternalRegistry{
-			ID:       "test/images.kontena.io",
+			ID:       api.ExternalRegistryID{"test", "images.kontena.io"},
 			Name:     "images.kontena.io",
 			URL:      "https://images.kontena.io",
 			Username: "test",

--- a/client/nodes.go
+++ b/client/nodes.go
@@ -1,44 +1,19 @@
 package client
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/kontena/kontena-client-go/api"
 )
 
-type NodeID struct {
-	Grid string
-	Name string
-}
-
-func ParseNodeID(id string) (nodeID NodeID, err error) {
-	parts := strings.Split(id, "/")
-
-	if len(parts) != 2 {
-		return nodeID, fmt.Errorf("Invalid NodeID: %#v", id)
-	}
-
-	nodeID.Grid = parts[0]
-	nodeID.Name = parts[1]
-
-	return nodeID, nil
-}
-
-func (nodeID NodeID) String() string {
-	return fmt.Sprintf("%s/%s", nodeID.Grid, nodeID.Name)
-}
-
 type NodesAPI interface {
 	List(grid string) ([]api.Node, error)
-	Get(id NodeID) (api.Node, error)
-	GetToken(id NodeID) (api.NodeToken, error)
+	Get(id api.NodeID) (api.Node, error)
+	GetToken(id api.NodeID) (api.NodeToken, error)
 	Create(grid string, params api.NodePOST) (api.Node, error)
-	CreateToken(id NodeID, params api.NodeTokenParams) (api.NodeToken, error)
-	Update(id NodeID, params api.NodePUT) (api.Node, error)
-	UpdateToken(id NodeID, token string, params api.NodeTokenParams) (api.NodeToken, error)
-	Delete(id NodeID) error
-	DeleteToken(id NodeID, params api.NodeTokenParams) error
+	CreateToken(id api.NodeID, params api.NodeTokenParams) (api.NodeToken, error)
+	Update(id api.NodeID, params api.NodePUT) (api.Node, error)
+	UpdateToken(id api.NodeID, token string, params api.NodeTokenParams) (api.NodeToken, error)
+	Delete(id api.NodeID) error
+	DeleteToken(id api.NodeID, params api.NodeTokenParams) error
 }
 
 type nodesClient struct {
@@ -51,13 +26,13 @@ func (nodesClient nodesClient) List(grid string) ([]api.Node, error) {
 	return nodes.Nodes, nodesClient.client.get(request{ResponseBody: &nodes}, "/v1/grids", grid, "nodes")
 }
 
-func (nodesClient nodesClient) Get(id NodeID) (api.Node, error) {
+func (nodesClient nodesClient) Get(id api.NodeID) (api.Node, error) {
 	var node api.Node
 
 	return node, nodesClient.client.get(request{ResponseBody: &node}, "/v1/nodes", id.String())
 }
 
-func (nodesClient nodesClient) GetToken(id NodeID) (api.NodeToken, error) {
+func (nodesClient nodesClient) GetToken(id api.NodeID) (api.NodeToken, error) {
 	var nodeToken api.NodeToken
 
 	return nodeToken, nodesClient.client.get(request{ResponseBody: &nodeToken}, "/v1/nodes", id.String(), "token")
@@ -69,20 +44,20 @@ func (nodesClient nodesClient) Create(grid string, params api.NodePOST) (api.Nod
 	return node, nodesClient.client.post(request{RequestBody: params, ResponseBody: &node}, "/v1/grids", grid, "nodes")
 }
 
-func (nodesClient nodesClient) CreateToken(id NodeID, params api.NodeTokenParams) (api.NodeToken, error) {
+func (nodesClient nodesClient) CreateToken(id api.NodeID, params api.NodeTokenParams) (api.NodeToken, error) {
 	var put = api.NodeTokenPUT{NodeTokenParams: params}
 	var nodeToken api.NodeToken
 
 	return nodeToken, nodesClient.client.put(request{RequestBody: put, ResponseBody: &nodeToken}, "/v1/nodes", id.String(), "token")
 }
 
-func (nodesClient nodesClient) Update(id NodeID, params api.NodePUT) (api.Node, error) {
+func (nodesClient nodesClient) Update(id api.NodeID, params api.NodePUT) (api.Node, error) {
 	var node api.Node
 
 	return node, nodesClient.client.put(request{RequestBody: params, ResponseBody: &node}, "/v1/nodes", id.String())
 }
 
-func (nodesClient nodesClient) UpdateToken(id NodeID, token string, params api.NodeTokenParams) (api.NodeToken, error) {
+func (nodesClient nodesClient) UpdateToken(id api.NodeID, token string, params api.NodeTokenParams) (api.NodeToken, error) {
 	var put = api.NodeTokenPUT{
 		Token:           token,
 		NodeTokenParams: params,
@@ -93,11 +68,11 @@ func (nodesClient nodesClient) UpdateToken(id NodeID, token string, params api.N
 	return nodeToken, nodesClient.client.put(request{RequestBody: put, ResponseBody: &nodeToken}, "/v1/nodes", id.String(), "token")
 }
 
-func (nodesClient nodesClient) Delete(id NodeID) error {
+func (nodesClient nodesClient) Delete(id api.NodeID) error {
 	return nodesClient.client.delete(request{}, "/v1/nodes", id.String())
 }
 
-func (nodesClient nodesClient) DeleteToken(id NodeID, params api.NodeTokenParams) error {
+func (nodesClient nodesClient) DeleteToken(id api.NodeID, params api.NodeTokenParams) error {
 	var requestBody = api.NodeTokenDELETE{
 		NodeTokenParams: params,
 	}

--- a/client/test-data/node.go
+++ b/client/test-data/node.go
@@ -7,7 +7,7 @@ import (
 )
 
 var Node = api.Node{
-	ID:            "test/terraform-test-node1",
+	ID:            api.NodeID{"test", "terraform-test-node1"},
 	NodeID:        "VAHL:WEKY:EVK7:7WUJ:2SQY:B5T7:36TT:NTUL:7CHW:XJA5:KBHL:RSTU",
 	Connected:     true,
 	CreatedAt:     (time.Date(2017, 6, 15, 21, 12, 26, 845000000, time.UTC)),


### PR DESCRIPTION
Breaks package API compatibility

* Moves `client.NodeID` => `api.NodeID`
* Change `api.Node.ID` and `api.ExternalRegistry.ID` from `string` => `struct FooID { ... }`
* Adds `api.ExternalRegistryID`
* `api.Parse*ID` now validates user input using a regexp